### PR TITLE
Fix defunct link

### DIFF
--- a/src/dn/PathFinder.hx
+++ b/src/dn/PathFinder.hx
@@ -48,6 +48,7 @@ private class AStarList {
 
 
 // Credits : http://www.policyalmanac.org/games/aStarTutorial.htm
+//  cached : https://gist.github.com/jcward/45afd22560939aaae5c75e68f1e57505
 
 typedef Path = Array<{x:Int, y:Int}>;
 


### PR DESCRIPTION
The link for the A* Pathfinder algorithm article is now defunct. I've recovered the content from web.archive.org and made a copy on gist:

https://gist.github.com/jcward/45afd22560939aaae5c75e68f1e57505
