### PR TITLE
Hacky support for pad left axes

### DIFF
--- a/src/dn/heaps/Controller.hx
+++ b/src/dn/heaps/Controller.hx
@@ -257,14 +257,14 @@ class ControllerAccess {
 		if( isKeyboard() )
 			return leftDown() ? -1 : rightDown() ? 1 : 0;
 		else
-			return parent.gc.getValue(AXIS_LEFT_X_POS, false, leftDeadZone);
+			return parent.gc.getLXValue(false, leftDeadZone);
 	}
 
 	public inline function lyValue() : Float {
 		if( isKeyboard() )
 			return upDown() ? -1 : downDown() ? 1 : 0;
 		else
-			return parent.gc.getValue(AXIS_LEFT_Y_POS, false, leftDeadZone);
+			return parent.gc.getLYValue(false, leftDeadZone);
 	}
 
 	public inline function rxValue()         return parent.gc.getValue(AXIS_RIGHT_X, false, rightDeadZone);

--- a/src/dn/heaps/GamePad.hx
+++ b/src/dn/heaps/GamePad.hx
@@ -158,11 +158,7 @@ class GamePad {
 			device.rumble(strength, time_s);
 	}
 
-	inline function getControlValue(idx:Int, simplified:Bool, overrideDeadZone:Float=-1.) : Float {
-		var v = idx > -1 && idx<device.values.length ? device.values[idx] : 0;
-		//if( inverts.get(cid)==true )
-		//	v*=-1;
-
+	function applyDeadZone(v:Float, simplified:Bool, overrideDeadZone:Float) : Float {
 		var dz : Float = overrideDeadZone < 0. ? deadZone : overrideDeadZone;
 
 		if( simplified )
@@ -170,9 +166,24 @@ class GamePad {
 		else
 			return v>-dz && v<dz ? 0. : v;
 	}
+	inline function getControlValue(idx:Int, simplified:Bool, overrideDeadZone:Float) : Float {
+		var v = idx > -1 && idx<device.values.length ? device.values[idx] : 0;
+		//if( inverts.get(cid)==true )
+		//	v*=-1;
+
+		return applyDeadZone(v, simplified, overrideDeadZone);
+	}
 
 	public inline function getValue(k:PadKey, simplified=false, overrideDeadZone:Float=-1.) : Float {
 		return isEnabled() ? getControlValue( MAPPING[k.getIndex()], simplified, overrideDeadZone ) : 0.;
+	}
+
+	public inline function getLXValue(simplified=false, overrideDeadZone:Float=-1.) : Float {
+		return isEnabled() ? applyDeadZone( device.xAxis, simplified, overrideDeadZone ) : 0.;
+	}
+
+	public inline function getLYValue(simplified=false, overrideDeadZone:Float=-1.) : Float {
+		return isEnabled() ? applyDeadZone( device.yAxis, simplified, overrideDeadZone ) : 0.;
 	}
 
 	public inline function checkDownStatus(k:PadKey) {


### PR DESCRIPTION
I tried to use your library and hit a bug when trying to use my old xbox controller. The values from the joystick did not work the way I was expecting them to.

This is a crappy fix that makes what I wanted work.

I suspect that a better solution would involve a better integration with the hxd,Pad interface.
I am also surprised by [this line](https://github.com/deepnight/deepnightLibs/blob/c2a914845cf1235e503ba59c3552597d534fc6e9/src/dn/heaps/Controller.hx#L260) and [that one](https://github.com/deepnight/deepnightLibs/blob/c2a914845cf1235e503ba59c3552597d534fc6e9/src/dn/heaps/Controller.hx#L267).
It looks like the keys should be `AXIS_LEFT_X` and `AXIS_LEFT_Y` respectively but I am not sure of the semantics you went for.

If you are interested in these changes, I am happy to make a more robust proposal, otherwise I will just maintain my own fork.