### PR TITLE
Fix crash with Castle

### DIFF
--- a/src/dn/data/GetText.hx
+++ b/src/dn/data/GetText.hx
@@ -710,6 +710,8 @@ class GetText {
 		}
 
 		function _exploreSheet( idx:String, id:Null<String>, lines:Array<Dynamic>, columns:Array<Array<String>> ){
+			if (lines == null) 
+				return;
 			var n = 0;
 			var i = 0;
 			for( line in lines ){


### PR DESCRIPTION
There was a crash when trying to parse the content of an empty cell in a localizable column of a cdb.