### PR TITLE
Make HSprite Animation independent of FPS changes

### DIFF
--- a/src/dn/heaps/slib/HSprite.hx
+++ b/src/dn/heaps/slib/HSprite.hx
@@ -1,5 +1,6 @@
 package dn.heaps.slib;
 
+import hxd.Timer;
 import h2d.Drawable;
 import dn.heaps.slib.*;
 import dn.heaps.slib.SpriteLib;
@@ -247,6 +248,6 @@ class HSprite extends h2d.Drawable implements SpriteInterface {
 	override function sync(ctx:h2d.RenderContext) {
 		super.sync(ctx);
 		if( animAllocated )
-			anim.update( lib!=null ? lib.tmod : 1 );
+			anim.update( lib!=null ? lib.tmod * Timer.tmod : Timer.tmod );
 	}
 }


### PR DESCRIPTION
The Sprite anim.update() function assumes a constant 60hz for display.
If the Timer.tmod changes during runtime, animations run faster and slower.
This became apparent when testing my game on my variable refresh rate Laptop and switching between 60hz and 144hz.
Using Timer.tmod in the anim.update fixes the issue.