### PR TITLE
Fix allTweens array modified while iterated

### DIFF
--- a/src/dn/Tweenie.hx
+++ b/src/dn/Tweenie.hx
@@ -439,8 +439,13 @@ class Tweenie {
 
 
 	public function update(dt=1.0) {
-		for (t in allTweens)
+		var i = 0;
+		while (i < allTweens.allocated) {
+			var t = allTweens.get(i);
 			if( t.internalUpdate(dt) )
 				allTweens.remove(t);
+			else 
+				i++;
+		}
 	}
 }


### PR DESCRIPTION
Elements should not be removed from an array while it's iterated using a regular iterator.  Removing an element while iterating this way result in jumping the one just after. This fixes the issue by iterating manually and not incrementing the index on a remove.