### PR TITLE
TiledTexture updates

### DIFF
--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -31,12 +31,14 @@ class TiledTexture extends h2d.TileGroup {
 		var y = 0;
 		var ox = M.round( -pivotX*width );
 		var oy = M.round( -pivotY*height );
+		var w = Std.int( tile.width );
+		var h = Std.int( tile.height );
 		while( y<height) {
 			add( x+ox, y+oy, tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height) ) );
-			x += Std.int(tile.width);
+			x += w;
 			if( x>=width ) {
 				x = 0;
-				y += Std.int(tile.height);
+				y += h;
 			}
 		}
 	}
@@ -51,26 +53,21 @@ class TiledTexture extends h2d.TileGroup {
 
 	override function drawTo(t:h3d.mat.Texture) {
 		if (tile == null) return;
-
-		if( invalidated ) {
-			invalidated = false;
-			build();
-		}
-
 		var x = 0;
 		var y = 0;
 		var ox = M.round( -pivotX*width );
 		var oy = M.round( -pivotY*height );
+		var w = Std.int( tile.width );
+		var h = Std.int( tile.height );
 		while( y<height) {
-			//add( x+ox, y+oy, tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height) ) );
-			var bmp = new h2d.Bitmap(tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height)));
+			var bmp = new h2d.Bitmap( tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height) ) );
 			bmp.x = x+ox;
 			bmp.y = y+oy;
 			bmp.drawTo(t);
-			x += Std.int(tile.width);
+			x += w
 			if( x>=width ) {
 				x = 0;
-				y += Std.int(tile.height);
+				y += h
 			}
 		}
 	}

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -8,8 +8,6 @@ class TiledTexture extends h2d.TileGroup {
 	public var pivotX(default,set) = 0.;
 	public var pivotY(default,set) = 0.;
 
-	public
-
 	public function new(wid:Int, hei:Int, ?texTile:h2d.Tile, ?p:h2d.Object) {
 		super(texTile, p);
 		width = wid;

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -48,4 +48,28 @@ class TiledTexture extends h2d.TileGroup {
 		}
 		super.sync(ctx);
 	}
+
+	override function drawTo(t:h3d.mat.Texture) {
+		if (tile == null) return;
+
+		if( invalidated ) {
+			invalidated = false;
+			build();
+		}
+
+		var x = 0;
+		var y = 0;
+		var ox = M.round( -pivotX*width );
+		var oy = M.round( -pivotY*height );
+		while( y<height) {
+			//add( x+ox, y+oy, tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height) ) );
+			var bmp = new h2d.Bitmap(tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height));
+			bmp.drawTo(t);
+			x += Std.int(tile.width);
+			if( x>=width ) {
+				x = 0;
+				y += Std.int(tile.height);
+			}
+		}
+	}
 }

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -49,7 +49,7 @@ class TiledTexture extends h2d.TileGroup {
 		super.sync(ctx);
 	}
 
-	override function drawTo(t:Texture) {
+	override function drawTo(t:h3d.mat.Texture) {
 		if ( invalidated ) {
 			invalidated = false;
 			build();

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -49,7 +49,7 @@ class TiledTexture extends h2d.TileGroup {
 		super.sync(ctx);
 	}
 
-	override function drawTo(t:texture) {
+	override function drawTo(t:Texture) {
 		if ( invalidated ) {
 			invalidated = false;
 			build();

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -64,6 +64,8 @@ class TiledTexture extends h2d.TileGroup {
 		while( y<height) {
 			//add( x+ox, y+oy, tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height) ) );
 			var bmp = new h2d.Bitmap(tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height)));
+			bmp.x = x+ox;
+			bmp.y = y+oy;
 			bmp.drawTo(t);
 			x += Std.int(tile.width);
 			if( x>=width ) {

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -48,26 +48,4 @@ class TiledTexture extends h2d.TileGroup {
 		}
 		super.sync(ctx);
 	}
-
-	override function drawTo(t:h3d.mat.Texture) {
-		if ( invalidated ) {
-			invalidated = false;
-			build();
-		}
-
-		if (tile == null) return;
-
-		var x = 0;
-		var y = 0;
-		var ox = M.round( -pivotX*width );
-		var oy = M.round( -pivotY*height );
-		while( y<height) {
-			tile.sub(x+ox, y+oy, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height)).drawTo(t);
-			x += Std.int(tile.width);
-			if( x>=width ) {
-				x = 0;
-				y += Std.int(tile.height);
-			}
-		}
-	}
 }

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -63,7 +63,7 @@ class TiledTexture extends h2d.TileGroup {
 		var oy = M.round( -pivotY*height );
 		while( y<height) {
 			//add( x+ox, y+oy, tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height) ) );
-			var bmp = new h2d.Bitmap(tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height));
+			var bmp = new h2d.Bitmap(tile.sub( 0, 0, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height)));
 			bmp.drawTo(t);
 			x += Std.int(tile.width);
 			if( x>=width ) {

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -48,4 +48,26 @@ class TiledTexture extends h2d.TileGroup {
 		}
 		super.sync(ctx);
 	}
+
+	override function drawTo(t:texture) {
+		if ( invalidated ) {
+			invalidated = false;
+			build();
+		}
+
+		if (tile == null) return;
+
+		var x = 0;
+		var y = 0;
+		var ox = M.round( -pivotX*width );
+		var oy = M.round( -pivotY*height );
+		while( y<height) {
+			tile.sub(x+ox, y+oy, M.fmin(width-x,tile.width), M.fmin(height-y,tile.height)).drawTo(t);
+			x += Std.int(tile.width);
+			if( x>=width ) {
+				x = 0;
+				y += Std.int(tile.height);
+			}
+		}
+	}
 }

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -67,7 +67,7 @@ class TiledTexture extends h2d.TileGroup {
 			x += w
 			if( x>=width ) {
 				x = 0;
-				y += h
+				y += h;
 			}
 		}
 	}

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -8,7 +8,9 @@ class TiledTexture extends h2d.TileGroup {
 	public var pivotX(default,set) = 0.;
 	public var pivotY(default,set) = 0.;
 
-	public function new(texTile:h2d.Tile, wid:Int, hei:Int, ?p:h2d.Object) {
+	public
+
+	public function new(wid:Int, hei:Int, ?texTile:h2d.Tile, ?p:h2d.Object) {
 		super(texTile, p);
 		width = wid;
 		height = hei;
@@ -26,6 +28,7 @@ class TiledTexture extends h2d.TileGroup {
 
 	function build() {
 		clear();
+		if (tile == null) return;
 		var x = 0;
 		var y = 0;
 		var ox = M.round( -pivotX*width );

--- a/src/dn/heaps/TiledTexture.hx
+++ b/src/dn/heaps/TiledTexture.hx
@@ -64,7 +64,7 @@ class TiledTexture extends h2d.TileGroup {
 			bmp.x = x+ox;
 			bmp.y = y+oy;
 			bmp.drawTo(t);
-			x += w
+			x += w;
 			if( x>=width ) {
 				x = 0;
 				y += h;


### PR DESCRIPTION
This PR is specifically created to introduce functionality and null safety to facilitate https://github.com/deepnight/ldtk/pull/853

Adds a null check to build() so that TiledTextures may be instantiated (and can have build() run) without an assigned tile.

Changes the constructor signature to allow for tile-less instantiation.

Adds an override for the drawTo(Texture) method, allowing TiledTextures to be rendered directly to Textures.

Performed some minor cleanup to make the build() loop more efficient.