### PR TITLE
Fix reification error with haxe 4.3

### DIFF
--- a/src/dn/heaps/assets/Aseprite.hx
+++ b/src/dn/heaps/assets/Aseprite.hx
@@ -39,7 +39,7 @@ class Aseprite {
 			// Define animation from timeline
 			var animFrames = [];
 			for(f in frames) {
-				var animFrameCount = dn.M.round( dn.M.fmax(1, $v{fps} * f.duration/1000) );
+				var animFrameCount = dn.M.round( dn.M.fmax(1, fps * f.duration/1000) );
 				for( i in 0...animFrameCount ) // HACK Spritelib anims are frame-based, which is bad :(
 					animFrames.push(f.index-baseIndex);
 			}


### PR DESCRIPTION
Fixes `Reification $v is not allowed outside of 'macro' expression`