### PR TITLE
Sfx doesn't compile when "macro" is true.

### DIFF
--- a/src/dn/heaps/Sfx.hx
+++ b/src/dn/heaps/Sfx.hx
@@ -548,6 +548,7 @@ private class GlobalGroup {
 
 
 
+#if !macro
 /**
 	A small helper class to pick sounds randomly from a list
 **/
@@ -592,3 +593,4 @@ class RandomSfxList {
 		return getters.map( g->g() );
 	}
 }
+#end


### PR DESCRIPTION
I suspect the new version of haxe broke the compilation of `Sfx.hx`.

This aims at making the module consistent in that, class `RandomSfxList` depends on `Sound` so it should probably only be there when `hxd.res.Sound` is imported.

An alternative to this solution would, of course, be to always import it, but I am not sure why the `#if !macro` is there in the first place.